### PR TITLE
Reduce string allocations while parsing

### DIFF
--- a/src/pemfile.rs
+++ b/src/pemfile.rs
@@ -34,7 +34,7 @@ impl Item {
 /// You can use this function to build an iterator, for example:
 /// `for item in iter::from_fn(|| read_one(rd).transpose()) { ... }`
 pub fn read_one(rd: &mut dyn io::BufRead) -> Result<Option<Item>, io::Error> {
-    let mut b64buf = String::new();
+    let mut b64buf = String::with_capacity(1024);
     let mut section_type = None;
     let mut end_marker = None;
     let mut line = String::with_capacity(80);


### PR DESCRIPTION
During benchmarkings, pemfile parsing can be seen to be spending
much time in b64buf.push_str() in flamegraphs. Setting a capacity
on the base64 stringbuffer shows about 10%-25% improvements in
the microbenchmarks

(eg. from 5.7688 us to  4.5753 us for tests/data/certificate.chain.pem)
