### PR TITLE
Add private key variant for EC based keys

### DIFF
--- a/src/pemfile.rs
+++ b/src/pemfile.rs
@@ -12,6 +12,9 @@ pub enum Item {
 
     /// A DER-encoded plaintext private key; as specified in PKCS#8/RFC5958
     PKCS8Key(Vec<u8>),
+
+    /// A DER-encoded plaintext EC private key;
+    ECKey(Vec<u8>),
 }
 
 impl Item {
@@ -20,6 +23,7 @@ impl Item {
             "CERTIFICATE" => Some(Item::X509Certificate(der)),
             "RSA PRIVATE KEY" => Some(Item::RSAKey(der)),
             "PRIVATE KEY" => Some(Item::PKCS8Key(der)),
+            "EC PRIVATE KEY" => Some(Item::ECKey(der)),
             _ => None,
         }
     }
@@ -46,16 +50,23 @@ pub fn read_one(rd: &mut dyn io::BufRead) -> Result<Option<Item>, io::Error> {
         if len == 0 {
             // EOF
             if end_marker.is_some() {
-                return Err(io::Error::new(ErrorKind::InvalidData, format!("section end {:?} missing", end_marker.unwrap())));
+                return Err(io::Error::new(
+                    ErrorKind::InvalidData,
+                    format!("section end {:?} missing", end_marker.unwrap()),
+                ));
             }
             return Ok(None);
         }
 
         if line.starts_with("-----BEGIN ") {
-            let trailer = line[11..].find("-----")
-                .ok_or_else(|| io::Error::new(ErrorKind::InvalidData, format!("illegal section start: {:?}", line)))?;
+            let trailer = line[11..].find("-----").ok_or_else(|| {
+                io::Error::new(
+                    ErrorKind::InvalidData,
+                    format!("illegal section start: {:?}", line),
+                )
+            })?;
 
-            let ty = &line[11..11+trailer];
+            let ty = &line[11..11 + trailer];
 
             section_type = Some(ty.to_string());
             end_marker = Some(format!("-----END {}-----", ty).to_string());

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -8,32 +8,42 @@ mod unit {
     #[test]
     fn skips_leading_junk() {
         assert_eq!(
-            check(b"junk\n\
+            check(
+                b"junk\n\
                     -----BEGIN RSA PRIVATE KEY-----\n\
                     qw\n\
-                    -----END RSA PRIVATE KEY-----\n").unwrap(),
-            vec![ crate::Item::RSAKey(vec![ 0xab ]) ]
+                    -----END RSA PRIVATE KEY-----\n"
+            )
+            .unwrap(),
+            vec![crate::Item::RSAKey(vec![0xab])]
         );
     }
 
     #[test]
     fn skips_trailing_junk() {
         assert_eq!(
-            check(b"-----BEGIN RSA PRIVATE KEY-----\n\
+            check(
+                b"-----BEGIN RSA PRIVATE KEY-----\n\
                     qw\n\
                     -----END RSA PRIVATE KEY-----\n\
-                    junk").unwrap(),
-            vec![ crate::Item::RSAKey(vec![ 0xab ]) ]
+                    junk"
+            )
+            .unwrap(),
+            vec![crate::Item::RSAKey(vec![0xab])]
         );
     }
 
     #[test]
     fn rejects_invalid_base64() {
         assert_eq!(
-            format!("{:?}",
-                    check(b"-----BEGIN RSA PRIVATE KEY-----\n\
+            format!(
+                "{:?}",
+                check(
+                    b"-----BEGIN RSA PRIVATE KEY-----\n\
                             q=w\n\
-                            -----END RSA PRIVATE KEY-----\n")),
+                            -----END RSA PRIVATE KEY-----\n"
+                )
+            ),
             "Err(Custom { kind: InvalidData, error: InvalidByte(1, 61) })"
         );
     }
@@ -62,11 +72,14 @@ mod unit {
     #[test]
     fn skips_unrecognised_section() {
         assert_eq!(
-            check(b"junk\n\
+            check(
+                b"junk\n\
                     -----BEGIN BREAKFAST CLUB-----\n\
                     qw\n\
-                    -----END BREAKFAST CLUB-----\n").unwrap(),
-            vec![ ]
+                    -----END BREAKFAST CLUB-----\n"
+            )
+            .unwrap(),
+            vec![]
         );
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6,8 +6,21 @@ fn test_rsa_private_keys() {
     let data = include_bytes!("data/zen2.pem");
     let mut reader = BufReader::new(&data[..]);
 
-    assert_eq!(rustls_pemfile::rsa_private_keys(&mut reader).unwrap().len(),
-               2);
+    assert_eq!(
+        rustls_pemfile::rsa_private_keys(&mut reader).unwrap().len(),
+        2
+    );
+}
+
+#[test]
+fn test_ec_private_keys() {
+    let data = include_bytes!("data/nistp256key.pem");
+    let mut reader = BufReader::new(&data[..]);
+
+    assert_eq!(
+        rustls_pemfile::ec_private_keys(&mut reader).unwrap().len(),
+        1
+    );
 }
 
 #[test]
@@ -15,8 +28,7 @@ fn test_certs() {
     let data = include_bytes!("data/certificate.chain.pem");
     let mut reader = BufReader::new(&data[..]);
 
-    assert_eq!(rustls_pemfile::certs(&mut reader).unwrap().len(),
-               3);
+    assert_eq!(rustls_pemfile::certs(&mut reader).unwrap().len(), 3);
 }
 
 #[test]
@@ -24,8 +36,12 @@ fn test_pkcs8() {
     let data = include_bytes!("data/zen.pem");
     let mut reader = BufReader::new(&data[..]);
 
-    assert_eq!(rustls_pemfile::pkcs8_private_keys(&mut reader).unwrap().len(),
-               2);
+    assert_eq!(
+        rustls_pemfile::pkcs8_private_keys(&mut reader)
+            .unwrap()
+            .len(),
+        2
+    );
 }
 
 #[test]
@@ -40,7 +56,7 @@ fn smoketest_iterate() {
         count += 1;
     }
 
-    assert_eq!(count, 14);
+    assert_eq!(count, 16);
 }
 
 #[test]
@@ -48,14 +64,14 @@ fn parse_in_order() {
     let data = include_bytes!("data/zen.pem");
     let mut reader = BufReader::new(&data[..]);
 
-    let items = rustls_pemfile::read_all(&mut reader)
-        .unwrap();
-    assert_eq!(items.len(), 7);
+    let items = rustls_pemfile::read_all(&mut reader).unwrap();
+    assert_eq!(items.len(), 8);
     assert!(matches!(items[0], rustls_pemfile::Item::X509Certificate(_)));
     assert!(matches!(items[1], rustls_pemfile::Item::X509Certificate(_)));
     assert!(matches!(items[2], rustls_pemfile::Item::X509Certificate(_)));
     assert!(matches!(items[3], rustls_pemfile::Item::X509Certificate(_)));
-    assert!(matches!(items[4], rustls_pemfile::Item::PKCS8Key(_)));
-    assert!(matches!(items[5], rustls_pemfile::Item::RSAKey(_)));
-    assert!(matches!(items[6], rustls_pemfile::Item::PKCS8Key(_)));
+    assert!(matches!(items[4], rustls_pemfile::Item::ECKey(_)));
+    assert!(matches!(items[5], rustls_pemfile::Item::PKCS8Key(_)));
+    assert!(matches!(items[6], rustls_pemfile::Item::RSAKey(_)));
+    assert!(matches!(items[7], rustls_pemfile::Item::PKCS8Key(_)));
 }


### PR DESCRIPTION
Submitting some work that allowed me to load EC keys with the rustls-mio examples. I ran cargo fmt which auto-formatted some stuff. Let me know if that's ok, or I can try to reformat this.