### PR TITLE
Add support for EC private keys

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@
 //!         Item::X509Certificate(cert) => println!("certificate {:?}", cert),
 //!         Item::RSAKey(key) => println!("rsa pkcs1 key {:?}", key),
 //!         Item::PKCS8Key(key) => println!("pkcs8 key {:?}", key),
+//!         _ => println!("unsupported PEM payload"),
 //!     }
 //! }
 //! ```
@@ -41,15 +42,9 @@
 #[cfg(test)]
 mod tests;
 
-
 /// --- Main crate APIs:
-
 mod pemfile;
-pub use pemfile::{
-    Item,
-    read_one,
-    read_all,
-};
+pub use pemfile::{read_all, read_one, Item};
 
 /// --- Legacy APIs:
 use std::io;
@@ -104,4 +99,3 @@ pub fn pkcs8_private_keys(rd: &mut dyn io::BufRead) -> Result<Vec<Vec<u8>>, io::
         };
     }
 }
-

--- a/src/pemfile.rs
+++ b/src/pemfile.rs
@@ -2,6 +2,7 @@ use base64;
 use std::io::{self, ErrorKind};
 
 /// The contents of a single recognised block in a PEM file.
+#[non_exhaustive]
 #[derive(Debug, PartialEq)]
 pub enum Item {
     /// A DER-encoded x509 certificate.

--- a/src/pemfile.rs
+++ b/src/pemfile.rs
@@ -12,6 +12,9 @@ pub enum Item {
 
     /// A DER-encoded plaintext private key; as specified in PKCS#8/RFC5958
     PKCS8Key(Vec<u8>),
+
+    /// A Sec1-encoded plaintext private key; as specified in RFC5915
+    ECKey(Vec<u8>),
 }
 
 impl Item {
@@ -20,6 +23,7 @@ impl Item {
             "CERTIFICATE" => Some(Item::X509Certificate(der)),
             "RSA PRIVATE KEY" => Some(Item::RSAKey(der)),
             "PRIVATE KEY" => Some(Item::PKCS8Key(der)),
+            "EC PRIVATE KEY" => Some(Item::ECKey(der)),
             _ => None,
         }
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6,8 +6,10 @@ fn test_rsa_private_keys() {
     let data = include_bytes!("data/zen2.pem");
     let mut reader = BufReader::new(&data[..]);
 
-    assert_eq!(rustls_pemfile::rsa_private_keys(&mut reader).unwrap().len(),
-               2);
+    assert_eq!(
+        rustls_pemfile::rsa_private_keys(&mut reader).unwrap().len(),
+        2
+    );
 }
 
 #[test]
@@ -15,8 +17,7 @@ fn test_certs() {
     let data = include_bytes!("data/certificate.chain.pem");
     let mut reader = BufReader::new(&data[..]);
 
-    assert_eq!(rustls_pemfile::certs(&mut reader).unwrap().len(),
-               3);
+    assert_eq!(rustls_pemfile::certs(&mut reader).unwrap().len(), 3);
 }
 
 #[test]
@@ -24,8 +25,12 @@ fn test_pkcs8() {
     let data = include_bytes!("data/zen.pem");
     let mut reader = BufReader::new(&data[..]);
 
-    assert_eq!(rustls_pemfile::pkcs8_private_keys(&mut reader).unwrap().len(),
-               2);
+    assert_eq!(
+        rustls_pemfile::pkcs8_private_keys(&mut reader)
+            .unwrap()
+            .len(),
+        2
+    );
 }
 
 #[test]
@@ -40,7 +45,7 @@ fn smoketest_iterate() {
         count += 1;
     }
 
-    assert_eq!(count, 14);
+    assert_eq!(count, 16);
 }
 
 #[test]
@@ -48,14 +53,14 @@ fn parse_in_order() {
     let data = include_bytes!("data/zen.pem");
     let mut reader = BufReader::new(&data[..]);
 
-    let items = rustls_pemfile::read_all(&mut reader)
-        .unwrap();
-    assert_eq!(items.len(), 7);
+    let items = rustls_pemfile::read_all(&mut reader).unwrap();
+    assert_eq!(items.len(), 8);
     assert!(matches!(items[0], rustls_pemfile::Item::X509Certificate(_)));
     assert!(matches!(items[1], rustls_pemfile::Item::X509Certificate(_)));
     assert!(matches!(items[2], rustls_pemfile::Item::X509Certificate(_)));
     assert!(matches!(items[3], rustls_pemfile::Item::X509Certificate(_)));
-    assert!(matches!(items[4], rustls_pemfile::Item::PKCS8Key(_)));
-    assert!(matches!(items[5], rustls_pemfile::Item::RSAKey(_)));
-    assert!(matches!(items[6], rustls_pemfile::Item::PKCS8Key(_)));
+    assert!(matches!(items[4], rustls_pemfile::Item::ECKey(_)));
+    assert!(matches!(items[5], rustls_pemfile::Item::PKCS8Key(_)));
+    assert!(matches!(items[6], rustls_pemfile::Item::RSAKey(_)));
+    assert!(matches!(items[7], rustls_pemfile::Item::PKCS8Key(_)));
 }


### PR DESCRIPTION
This adds support for [EC PRIVATE KEY](https://datatracker.ietf.org/doc/html/rfc5915).