### PR TITLE
Prepare 1.0.1 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "rustls-pemfile"
 version = "1.0.1"
-authors = ["Joseph Birr-Pixton <jpixton@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0/ISC/MIT"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rustls-pemfile"
 version = "1.0.1"
 edition = "2018"
-license = "Apache-2.0/ISC/MIT"
+license = "Apache-2.0 OR ISC OR MIT"
 readme = "README.md"
 description = "Basic .pem file parser for keys and certificates"
 homepage = "https://github.com/rustls/pemfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-pemfile"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Joseph Birr-Pixton <jpixton@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0/ISC/MIT"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ poor and doing so doesn't address a meaningful threat model.
 [![Documentation](https://docs.rs/rustls-pemfile/badge.svg)](https://docs.rs/rustls-pemfile/)
 
 # Release history
+- 1.0.1 (2022-08-02)
+  * Enable parsing PEM files with non-UTF-8 content between items.
 - 1.0.0 (2022-04-14)
   * Initial stable release. No API changes.
 - 0.3.0 (2022-02-05)
@@ -29,4 +31,3 @@ rustls-pemfile is distributed under the following three licenses:
 These are included as LICENSE-APACHE, LICENSE-MIT and LICENSE-ISC
 respectively.  You may use this software under the terms of any
 of these licenses, at your option.
-


### PR DESCRIPTION
To get #7 out.

- [x] Updated changelog
- [x] Updated Cargo metadata
- [x] Dependencies are up to date
- [x] `cargo test --all-features`
- [x] `cargo publish --dry-run`