### PR TITLE
Update dependencies and prepare 1.0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["network-programming", "cryptography"]
 base64 = "0.21"
 
 [dev-dependencies]
-criterion = "0.3"
+bencher = "0.1.5"
 
 [[bench]]
 name = "benchmark"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/rustls/pemfile"
 categories = ["network-programming", "cryptography"]
 
 [dependencies]
-base64 = "0.13.0"
+base64 = "0.21"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-pemfile"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2018"
 license = "Apache-2.0 OR ISC OR MIT"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ poor and doing so doesn't address a meaningful threat model.
 [![Documentation](https://docs.rs/rustls-pemfile/badge.svg)](https://docs.rs/rustls-pemfile/)
 
 # Release history
+- 1.0.2 (2023-01-09)
+  * Update base64 to the latest version.
 - 1.0.1 (2022-08-02)
   * Enable parsing PEM files with non-UTF-8 content between items.
 - 1.0.0 (2022-04-14)

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,24 +1,14 @@
-use criterion::{criterion_group, criterion_main, Criterion};
 use std::io::BufReader;
 
-#[test]
-fn test_certs() {}
+use bencher::{benchmark_group, benchmark_main, Bencher};
 
-fn parse_cert() {
-    let data = include_bytes!("../tests/data/certificate.chain.pem");
-    let mut reader = BufReader::new(&data[..]);
-
-    assert_eq!(
-        rustls_pemfile::certs(&mut reader)
-            .unwrap()
-            .len(),
-        3
-    );
+fn criterion_benchmark(c: &mut Bencher) {
+    c.iter(|| {
+        let data = include_bytes!("../tests/data/certificate.chain.pem");
+        let mut reader = BufReader::new(&data[..]);
+        assert_eq!(rustls_pemfile::certs(&mut reader).unwrap().len(), 3);
+    });
 }
 
-fn criterion_benchmark(c: &mut Criterion) {
-    c.bench_function("parse cert chain", |b| b.iter(|| parse_cert()));
-}
-
-criterion_group!(benches, criterion_benchmark);
-criterion_main!(benches);
+benchmark_group!(benches, criterion_benchmark);
+benchmark_main!(benches);


### PR DESCRIPTION
Switch from criterion to bencher, as seen in rustls.

- [x] README updated with new changelog entry
- [x] Checked that dependencies are up to date
- [x] `cargo test --all-features` passes locally
- [x] `cargo publish --dry-run` passes locally