### PR TITLE
CI: update workflow actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install ${{ matrix.rust }} toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
 
       - name: cargo test (debug)
         run: cargo test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
             rust: stable
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install ${{ matrix.rust }} toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
           - stable
           - beta
           - nightly
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
         # but only stable on macos/windows (slower platforms)
         include:
           - os: macos-latest


### PR DESCRIPTION
To address [a pending deprecation](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/), and to remove CI warnings this branch brings the CI improvements that landed on the rustls/rustls repo in https://github.com/rustls/rustls/pull/1214 to this repo.

## CI: configure Dependabot for GitHub actions/crates.
This commit adds Dependabot support to the `pemfile` crate to match usage in the other rustls repositories.

Dependabot will monitor both Cargo dependencies and GitHub action workflow dependencies.

## CI: actions/checkout@v2 -> v3.
Does what it says on the tin.

## CI: replace actions-rs w/ dtolnay/rust-toolchain.
This commit replaces the actions-rs/toolchain action with dtolnay/rust-toolchain. The former is [no longer maintained](https://github.com/actions-rs/toolchain/issues/216).

## CI: update runs-on Ubuntu 18.04->20.04
This commit updates the build runner OS from 20.04 to 20.04, the [oldest supported](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners) version of Ubuntu offered by GitHub.

Ubuntu 18.04 runners are [deprecated by GitHub](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/).
