### PR TITLE
Adding private key getter to `Item`

### DIFF
--- a/src/pemfile.rs
+++ b/src/pemfile.rs
@@ -2,7 +2,7 @@ use std::io::{self, ErrorKind};
 
 /// The contents of a single recognised block in a PEM file.
 #[non_exhaustive]
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Item {
     /// A DER-encoded x509 certificate.
     X509Certificate(Vec<u8>),
@@ -24,6 +24,17 @@ impl Item {
             b"RSA PRIVATE KEY" => Some(Item::RSAKey(der)),
             b"PRIVATE KEY" => Some(Item::PKCS8Key(der)),
             b"EC PRIVATE KEY" => Some(Item::ECKey(der)),
+            _ => None,
+        }
+    }
+
+    /// Get the bytes of a private key.
+    /// If the `Item` is not a private key, returns `None`.
+    pub fn key(self) -> Option<Vec<u8>> {
+        match self {
+            Item::ECKey(bytes) => Some(bytes),
+            Item::RSAKey(bytes) => Some(bytes),
+            Item::PKCS8Key(bytes) => Some(bytes),
             _ => None,
         }
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -86,6 +86,38 @@ fn test_sec1_vs_pkcs8() {
 }
 
 #[test]
+fn test_key_getter() {
+    {
+        let data = include_bytes!("data/nistp256key.pem");
+        let mut reader = BufReader::new(&data[..]);
+        let item = rustls_pemfile::read_one(&mut reader).unwrap();
+        let key = item.map(|x| x.key()).unwrap();
+        assert!(key.is_some());
+    }
+    {
+        let data = include_bytes!("data/rsa1024.pkcs1.pem");
+        let mut reader = BufReader::new(&data[..]);
+        let item = rustls_pemfile::read_one(&mut reader).unwrap();
+        let key = item.map(|x| x.key()).unwrap();
+        assert!(key.is_some());
+    }
+    {
+        let data = include_bytes!("data/rsa1024.pkcs8.pem");
+        let mut reader = BufReader::new(&data[..]);
+        let item = rustls_pemfile::read_one(&mut reader).unwrap();
+        let key = item.map(|x| x.key()).unwrap();
+        assert!(key.is_some());
+    }
+    {
+        let data = include_bytes!("data/certificate.pem");
+        let mut reader = BufReader::new(&data[..]);
+        let item = rustls_pemfile::read_one(&mut reader).unwrap();
+        let key = item.map(|x| x.key()).unwrap();
+        assert!(key.is_none());
+    }
+}
+
+#[test]
 fn parse_in_order() {
     let data = include_bytes!("data/zen.pem");
     let mut reader = BufReader::new(&data[..]);


### PR DESCRIPTION
This relates to the idea proposed in #18.

## Implementation Notes
I derived `Clone` on `Item` as well, since `key(self)` will consume `Item` and, especially if called on a non-key, there should be a way to preserve the original `Item`.

## Considered Alternatives
We could change `key` to take a `&self`. This could either return:
1. `Option<Vec<u8>>`, where the Vec is cloned. This felt wrong, since if the `Item` is not used again, it results in an unneeded allocation.
2. `Option<&[u8]>`. This doesn't lend well to using `map`, since it would return a local reference.