### PR TITLE
ci: add fmt, clippy, doc checking. Forbid warns.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,28 @@ on: [push, pull_request]
 name: rustls-pemfile
 
 jobs:
+  rustfmt:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - uses: actions/checkout@v3
+      - run: cargo fmt --all -- --check
+  clippy:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: actions/checkout@v3
+      - run: cargo clippy --all-features --all-targets
+  rustdoc:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@v3
+      - run: cargo doc --all-features
   build:
     name: "Build and test"
     runs-on: ${{ matrix.os }}
@@ -32,7 +54,9 @@ jobs:
         run: cargo test
         env:
           RUST_BACKTRACE: 1
+          RUSTFLAGS: "-D warnings"
 
       - name: cargo test (release)
         run: cargo test --release
-
+        env:
+          RUSTFLAGS: "-D warnings"


### PR DESCRIPTION
This commit extends the existing CI to add more coverage:

* We check formatting with `cargo fmt`
* We check lints with `cargo clippy`
* We verify docs build with `cargo doc`

Additionally the `cargo test` steps are updated to forbid compiler warnings.