### PR TITLE
Switch to using the pki-types crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["network-programming", "cryptography"]
 
 [dependencies]
 base64 = "0.21"
+pki-types = { package = "rustls-pki-types", version = "0.1" }
 
 [dev-dependencies]
 bencher = "0.1.5"

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -6,7 +6,13 @@ fn criterion_benchmark(c: &mut Bencher) {
     c.iter(|| {
         let data = include_bytes!("../tests/data/certificate.chain.pem");
         let mut reader = BufReader::new(&data[..]);
-        assert_eq!(rustls_pemfile::certs(&mut reader).unwrap().len(), 3);
+        assert_eq!(
+            rustls_pemfile::certs(&mut reader)
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap()
+                .len(),
+            3
+        );
     });
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,22 +54,21 @@ use pki_types::{
 
 /// --- Legacy APIs:
 use std::io;
+use std::iter;
 
 /// Extract all the certificates from `rd`, and return a vec of byte vecs
 /// containing the der-format contents.
 ///
 /// This function does not fail if there are no certificates in the file --
 /// it returns an empty vector.
-pub fn certs(rd: &mut dyn io::BufRead) -> Result<Vec<CertificateDer<'static>>, io::Error> {
-    let mut certs = Vec::new();
-
-    loop {
-        match read_one(rd)? {
-            None => return Ok(certs),
-            Some(Item::X509Certificate(cert)) => certs.push(cert),
-            _ => {}
-        };
-    }
+pub fn certs(
+    rd: &mut dyn io::BufRead,
+) -> impl Iterator<Item = Result<CertificateDer<'static>, io::Error>> + '_ {
+    iter::from_fn(move || read_one(rd).transpose()).filter_map(|item| match item {
+        Ok(Item::X509Certificate(cert)) => Some(Ok(cert)),
+        Err(err) => Some(Err(err)),
+        _ => None,
+    })
 }
 
 /// Extract all the certificate revocation lists (CRLs) from `rd`, and return a vec of byte vecs
@@ -79,16 +78,12 @@ pub fn certs(rd: &mut dyn io::BufRead) -> Result<Vec<CertificateDer<'static>>, i
 /// it returns an empty vector.
 pub fn crls(
     rd: &mut dyn io::BufRead,
-) -> Result<Vec<CertificateRevocationListDer<'static>>, io::Error> {
-    let mut crls = Vec::new();
-
-    loop {
-        match read_one(rd)? {
-            None => return Ok(crls),
-            Some(Item::Crl(crl)) => crls.push(crl),
-            _ => {}
-        };
-    }
+) -> impl Iterator<Item = Result<CertificateRevocationListDer<'static>, io::Error>> + '_ {
+    iter::from_fn(move || read_one(rd).transpose()).filter_map(|item| match item {
+        Ok(Item::Crl(crl)) => Some(Ok(crl)),
+        Err(err) => Some(Err(err)),
+        _ => None,
+    })
 }
 
 /// Extract all RSA private keys from `rd`, and return a vec of byte vecs
@@ -98,16 +93,12 @@ pub fn crls(
 /// empty vector.
 pub fn rsa_private_keys(
     rd: &mut dyn io::BufRead,
-) -> Result<Vec<PrivatePkcs1KeyDer<'static>>, io::Error> {
-    let mut keys = Vec::new();
-
-    loop {
-        match read_one(rd)? {
-            None => return Ok(keys),
-            Some(Item::RSAKey(key)) => keys.push(key),
-            _ => {}
-        };
-    }
+) -> impl Iterator<Item = Result<PrivatePkcs1KeyDer<'static>, io::Error>> + '_ {
+    iter::from_fn(move || read_one(rd).transpose()).filter_map(|item| match item {
+        Ok(Item::RSAKey(key)) => Some(Ok(key)),
+        Err(err) => Some(Err(err)),
+        _ => None,
+    })
 }
 
 /// Extract all PKCS8-encoded private keys from `rd`, and return a vec of
@@ -117,16 +108,12 @@ pub fn rsa_private_keys(
 /// empty vector.
 pub fn pkcs8_private_keys(
     rd: &mut dyn io::BufRead,
-) -> Result<Vec<PrivatePkcs8KeyDer<'static>>, io::Error> {
-    let mut keys = Vec::new();
-
-    loop {
-        match read_one(rd)? {
-            None => return Ok(keys),
-            Some(Item::PKCS8Key(key)) => keys.push(key),
-            _ => {}
-        };
-    }
+) -> impl Iterator<Item = Result<PrivatePkcs8KeyDer<'static>, io::Error>> + '_ {
+    iter::from_fn(move || read_one(rd).transpose()).filter_map(|item| match item {
+        Ok(Item::PKCS8Key(key)) => Some(Ok(key)),
+        Err(err) => Some(Err(err)),
+        _ => None,
+    })
 }
 
 /// Extract all SEC1-encoded EC private keys from `rd`, and return a vec of
@@ -136,14 +123,10 @@ pub fn pkcs8_private_keys(
 /// empty vector.
 pub fn ec_private_keys(
     rd: &mut dyn io::BufRead,
-) -> Result<Vec<PrivateSec1KeyDer<'static>>, io::Error> {
-    let mut keys = Vec::new();
-
-    loop {
-        match read_one(rd)? {
-            None => return Ok(keys),
-            Some(Item::ECKey(key)) => keys.push(key),
-            _ => {}
-        };
-    }
+) -> impl Iterator<Item = Result<PrivateSec1KeyDer<'static>, io::Error>> + '_ {
+    iter::from_fn(move || read_one(rd).transpose()).filter_map(|item| match item {
+        Ok(Item::ECKey(key)) => Some(Ok(key)),
+        Err(err) => Some(Err(err)),
+        _ => None,
+    })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,10 @@ mod tests;
 /// --- Main crate APIs:
 mod pemfile;
 pub use pemfile::{read_all, read_one, Item};
+use pki_types::{
+    CertificateDer, CertificateRevocationListDer, PrivatePkcs1KeyDer, PrivatePkcs8KeyDer,
+    PrivateSec1KeyDer,
+};
 
 /// --- Legacy APIs:
 use std::io;
@@ -56,7 +60,7 @@ use std::io;
 ///
 /// This function does not fail if there are no certificates in the file --
 /// it returns an empty vector.
-pub fn certs(rd: &mut dyn io::BufRead) -> Result<Vec<Vec<u8>>, io::Error> {
+pub fn certs(rd: &mut dyn io::BufRead) -> Result<Vec<CertificateDer<'static>>, io::Error> {
     let mut certs = Vec::new();
 
     loop {
@@ -73,7 +77,9 @@ pub fn certs(rd: &mut dyn io::BufRead) -> Result<Vec<Vec<u8>>, io::Error> {
 ///
 /// This function does not fail if there are no CRLs in the file --
 /// it returns an empty vector.
-pub fn crls(rd: &mut dyn io::BufRead) -> Result<Vec<Vec<u8>>, io::Error> {
+pub fn crls(
+    rd: &mut dyn io::BufRead,
+) -> Result<Vec<CertificateRevocationListDer<'static>>, io::Error> {
     let mut crls = Vec::new();
 
     loop {
@@ -90,7 +96,9 @@ pub fn crls(rd: &mut dyn io::BufRead) -> Result<Vec<Vec<u8>>, io::Error> {
 ///
 /// This function does not fail if there are no keys in the file -- it returns an
 /// empty vector.
-pub fn rsa_private_keys(rd: &mut dyn io::BufRead) -> Result<Vec<Vec<u8>>, io::Error> {
+pub fn rsa_private_keys(
+    rd: &mut dyn io::BufRead,
+) -> Result<Vec<PrivatePkcs1KeyDer<'static>>, io::Error> {
     let mut keys = Vec::new();
 
     loop {
@@ -107,7 +115,9 @@ pub fn rsa_private_keys(rd: &mut dyn io::BufRead) -> Result<Vec<Vec<u8>>, io::Er
 ///
 /// This function does not fail if there are no keys in the file -- it returns an
 /// empty vector.
-pub fn pkcs8_private_keys(rd: &mut dyn io::BufRead) -> Result<Vec<Vec<u8>>, io::Error> {
+pub fn pkcs8_private_keys(
+    rd: &mut dyn io::BufRead,
+) -> Result<Vec<PrivatePkcs8KeyDer<'static>>, io::Error> {
     let mut keys = Vec::new();
 
     loop {
@@ -124,7 +134,9 @@ pub fn pkcs8_private_keys(rd: &mut dyn io::BufRead) -> Result<Vec<Vec<u8>>, io::
 ///
 /// This function does not fail if there are no keys in the file -- it returns an
 /// empty vector.
-pub fn ec_private_keys(rd: &mut dyn io::BufRead) -> Result<Vec<Vec<u8>>, io::Error> {
+pub fn ec_private_keys(
+    rd: &mut dyn io::BufRead,
+) -> Result<Vec<PrivateSec1KeyDer<'static>>, io::Error> {
     let mut keys = Vec::new();
 
     loop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,9 +22,9 @@
 //!     match item.unwrap() {
 //!         Item::X509Certificate(cert) => println!("certificate {:?}", cert),
 //!         Item::Crl(crl) => println!("certificate revocation list: {:?}", crl),
-//!         Item::RSAKey(key) => println!("rsa pkcs1 key {:?}", key),
-//!         Item::PKCS8Key(key) => println!("pkcs8 key {:?}", key),
-//!         Item::ECKey(key) => println!("sec1 ec key {:?}", key),
+//!         Item::Pkcs1Key(key) => println!("rsa pkcs1 key {:?}", key),
+//!         Item::Pkcs8Key(key) => println!("pkcs8 key {:?}", key),
+//!         Item::Sec1Key(key) => println!("sec1 ec key {:?}", key),
 //!         _ => println!("unhandled item"),
 //!     }
 //! }
@@ -95,7 +95,7 @@ pub fn rsa_private_keys(
     rd: &mut dyn io::BufRead,
 ) -> impl Iterator<Item = Result<PrivatePkcs1KeyDer<'static>, io::Error>> + '_ {
     iter::from_fn(move || read_one(rd).transpose()).filter_map(|item| match item {
-        Ok(Item::RSAKey(key)) => Some(Ok(key)),
+        Ok(Item::Pkcs1Key(key)) => Some(Ok(key)),
         Err(err) => Some(Err(err)),
         _ => None,
     })
@@ -110,7 +110,7 @@ pub fn pkcs8_private_keys(
     rd: &mut dyn io::BufRead,
 ) -> impl Iterator<Item = Result<PrivatePkcs8KeyDer<'static>, io::Error>> + '_ {
     iter::from_fn(move || read_one(rd).transpose()).filter_map(|item| match item {
-        Ok(Item::PKCS8Key(key)) => Some(Ok(key)),
+        Ok(Item::Pkcs8Key(key)) => Some(Ok(key)),
         Err(err) => Some(Err(err)),
         _ => None,
     })
@@ -125,7 +125,7 @@ pub fn ec_private_keys(
     rd: &mut dyn io::BufRead,
 ) -> impl Iterator<Item = Result<PrivateSec1KeyDer<'static>, io::Error>> + '_ {
     iter::from_fn(move || read_one(rd).transpose()).filter_map(|item| match item {
-        Ok(Item::ECKey(key)) => Some(Ok(key)),
+        Ok(Item::Sec1Key(key)) => Some(Ok(key)),
         Err(err) => Some(Err(err)),
         _ => None,
     })

--- a/src/pemfile.rs
+++ b/src/pemfile.rs
@@ -11,18 +11,28 @@ use pki_types::{
 #[derive(Debug, PartialEq)]
 pub enum Item {
     /// A DER-encoded x509 certificate.
+    ///
+    /// Appears as "CERTIFICATE" in PEM files.
     X509Certificate(CertificateDer<'static>),
 
-    /// A DER-encoded plaintext RSA private key; as specified in PKCS#1/RFC3447
-    RSAKey(PrivatePkcs1KeyDer<'static>),
+    /// A DER-encoded plaintext RSA private key; as specified in PKCS #1/RFC 3447
+    ///
+    /// Appears as "RSA PRIVATE KEY" in PEM files.
+    Pkcs1Key(PrivatePkcs1KeyDer<'static>),
 
-    /// A DER-encoded plaintext private key; as specified in PKCS#8/RFC5958
-    PKCS8Key(PrivatePkcs8KeyDer<'static>),
+    /// A DER-encoded plaintext private key; as specified in PKCS #8/RFC 5958
+    ///
+    /// Appears as "PRIVATE KEY" in PEM files.
+    Pkcs8Key(PrivatePkcs8KeyDer<'static>),
 
-    /// A Sec1-encoded plaintext private key; as specified in RFC5915
-    ECKey(PrivateSec1KeyDer<'static>),
+    /// A Sec1-encoded plaintext private key; as specified in RFC 5915
+    ///
+    /// Appears as "EC PRIVATE KEY" in PEM files.
+    Sec1Key(PrivateSec1KeyDer<'static>),
 
-    /// A Certificate Revocation List; as specified in RFC5280
+    /// A Certificate Revocation List; as specified in RFC 5280
+    ///
+    /// Appears as "X509 CRL" in PEM files.
     Crl(CertificateRevocationListDer<'static>),
 }
 
@@ -97,9 +107,9 @@ pub fn read_one(rd: &mut dyn io::BufRead) -> Result<Option<Item>, io::Error> {
 
                 match section_type.as_slice() {
                     b"CERTIFICATE" => return Ok(Some(Item::X509Certificate(der.into()))),
-                    b"RSA PRIVATE KEY" => return Ok(Some(Item::RSAKey(der.into()))),
-                    b"PRIVATE KEY" => return Ok(Some(Item::PKCS8Key(der.into()))),
-                    b"EC PRIVATE KEY" => return Ok(Some(Item::ECKey(der.into()))),
+                    b"RSA PRIVATE KEY" => return Ok(Some(Item::Pkcs1Key(der.into()))),
+                    b"PRIVATE KEY" => return Ok(Some(Item::Pkcs8Key(der.into()))),
+                    b"EC PRIVATE KEY" => return Ok(Some(Item::Sec1Key(der.into()))),
                     b"X509 CRL" => return Ok(Some(Item::Crl(der.into()))),
                     _ => {
                         section = None;

--- a/src/pemfile.rs
+++ b/src/pemfile.rs
@@ -1,4 +1,5 @@
 use std::io::{self, ErrorKind};
+use std::iter;
 
 use pki_types::{
     CertificateDer, CertificateRevocationListDer, PrivatePkcs1KeyDer, PrivatePkcs8KeyDer,
@@ -122,15 +123,8 @@ pub fn read_one(rd: &mut dyn io::BufRead) -> Result<Option<Item>, io::Error> {
 }
 
 /// Extract and return all PEM sections by reading `rd`.
-pub fn read_all(rd: &mut dyn io::BufRead) -> Result<Vec<Item>, io::Error> {
-    let mut v = Vec::<Item>::new();
-
-    loop {
-        match read_one(rd)? {
-            None => return Ok(v),
-            Some(item) => v.push(item),
-        }
-    }
+pub fn read_all(rd: &mut dyn io::BufRead) -> impl Iterator<Item = Result<Item, io::Error>> + '_ {
+    iter::from_fn(move || read_one(rd).transpose())
 }
 
 mod base64 {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -15,7 +15,7 @@ mod unit {
                     -----END RSA PRIVATE KEY-----\n"
             )
             .unwrap(),
-            vec![crate::Item::RSAKey(vec![0xab])]
+            vec![crate::Item::RSAKey(vec![0xab].into())]
         );
     }
 
@@ -29,7 +29,7 @@ mod unit {
                     junk"
             )
             .unwrap(),
-            vec![crate::Item::RSAKey(vec![0xab])]
+            vec![crate::Item::RSAKey(vec![0xab].into())]
         );
     }
 
@@ -44,7 +44,7 @@ mod unit {
                     \x00\x00"
             )
             .unwrap(),
-            vec![crate::Item::RSAKey(vec![0xab])]
+            vec![crate::Item::RSAKey(vec![0xab].into())]
         );
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -15,7 +15,7 @@ mod unit {
                     -----END RSA PRIVATE KEY-----\n"
             )
             .unwrap(),
-            vec![crate::Item::RSAKey(vec![0xab].into())]
+            vec![crate::Item::Pkcs1Key(vec![0xab].into())]
         );
     }
 
@@ -29,7 +29,7 @@ mod unit {
                     junk"
             )
             .unwrap(),
-            vec![crate::Item::RSAKey(vec![0xab].into())]
+            vec![crate::Item::Pkcs1Key(vec![0xab].into())]
         );
     }
 
@@ -44,7 +44,7 @@ mod unit {
                     \x00\x00"
             )
             .unwrap(),
-            vec![crate::Item::RSAKey(vec![0xab].into())]
+            vec![crate::Item::Pkcs1Key(vec![0xab].into())]
         );
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,7 +2,7 @@
 mod unit {
     fn check(data: &[u8]) -> Result<Vec<crate::Item>, std::io::Error> {
         let mut reader = std::io::BufReader::new(data);
-        crate::read_all(&mut reader)
+        crate::read_all(&mut reader).collect()
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -78,7 +78,7 @@ fn test_sec1() {
         .collect::<Result<Vec<_>, _>>()
         .unwrap();
     assert_eq!(items.len(), 1);
-    assert!(matches!(items[0], rustls_pemfile::Item::ECKey(_)));
+    assert!(matches!(items[0], rustls_pemfile::Item::Sec1Key(_)));
 }
 
 #[test]
@@ -105,7 +105,7 @@ fn test_sec1_vs_pkcs8() {
         let items = rustls_pemfile::read_all(&mut reader)
             .collect::<Result<Vec<_>, _>>()
             .unwrap();
-        assert!(matches!(items[0], rustls_pemfile::Item::ECKey(_)));
+        assert!(matches!(items[0], rustls_pemfile::Item::Sec1Key(_)));
         println!("sec1 {:?}", items);
     }
     {
@@ -115,7 +115,7 @@ fn test_sec1_vs_pkcs8() {
         let items = rustls_pemfile::read_all(&mut reader)
             .collect::<Result<Vec<_>, _>>()
             .unwrap();
-        assert!(matches!(items[0], rustls_pemfile::Item::PKCS8Key(_)));
+        assert!(matches!(items[0], rustls_pemfile::Item::Pkcs8Key(_)));
         println!("p8 {:?}", items);
     }
 }
@@ -133,9 +133,9 @@ fn parse_in_order() {
     assert!(matches!(items[1], rustls_pemfile::Item::X509Certificate(_)));
     assert!(matches!(items[2], rustls_pemfile::Item::X509Certificate(_)));
     assert!(matches!(items[3], rustls_pemfile::Item::X509Certificate(_)));
-    assert!(matches!(items[4], rustls_pemfile::Item::ECKey(_)));
-    assert!(matches!(items[5], rustls_pemfile::Item::PKCS8Key(_)));
-    assert!(matches!(items[6], rustls_pemfile::Item::RSAKey(_)));
-    assert!(matches!(items[7], rustls_pemfile::Item::PKCS8Key(_)));
+    assert!(matches!(items[4], rustls_pemfile::Item::Sec1Key(_)));
+    assert!(matches!(items[5], rustls_pemfile::Item::Pkcs8Key(_)));
+    assert!(matches!(items[6], rustls_pemfile::Item::Pkcs1Key(_)));
+    assert!(matches!(items[7], rustls_pemfile::Item::Pkcs8Key(_)));
     assert!(matches!(items[8], rustls_pemfile::Item::Crl(_)));
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7,7 +7,10 @@ fn test_rsa_private_keys() {
     let mut reader = BufReader::new(&data[..]);
 
     assert_eq!(
-        rustls_pemfile::rsa_private_keys(&mut reader).unwrap().len(),
+        rustls_pemfile::rsa_private_keys(&mut reader)
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+            .len(),
         2
     );
 }
@@ -17,21 +20,39 @@ fn test_certs() {
     let data = include_bytes!("data/certificate.chain.pem");
     let mut reader = BufReader::new(&data[..]);
 
-    assert_eq!(rustls_pemfile::certs(&mut reader).unwrap().len(), 3);
+    assert_eq!(
+        rustls_pemfile::certs(&mut reader)
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+            .len(),
+        3
+    );
 }
 
 #[test]
 fn test_certs_with_binary() {
     let data = include_bytes!("data/gunk.pem");
     let mut reader = BufReader::new(&data[..]);
-    assert_eq!(rustls_pemfile::certs(&mut reader).unwrap().len(), 2);
+    assert_eq!(
+        rustls_pemfile::certs(&mut reader)
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+            .len(),
+        2
+    );
 }
 
 #[test]
 fn test_crls() {
     let data = include_bytes!("data/crl.pem");
     let mut reader = BufReader::new(&data[..]);
-    assert_eq!(rustls_pemfile::crls(&mut reader).unwrap().len(), 1);
+    assert_eq!(
+        rustls_pemfile::crls(&mut reader)
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+            .len(),
+        1
+    );
 }
 
 #[test]
@@ -41,6 +62,7 @@ fn test_pkcs8() {
 
     assert_eq!(
         rustls_pemfile::pkcs8_private_keys(&mut reader)
+            .collect::<Result<Vec<_>, _>>()
             .unwrap()
             .len(),
         2
@@ -52,7 +74,9 @@ fn test_sec1() {
     let data = include_bytes!("data/nistp256key.pem");
     let mut reader = BufReader::new(&data[..]);
 
-    let items = rustls_pemfile::read_all(&mut reader).unwrap();
+    let items = rustls_pemfile::read_all(&mut reader)
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
     assert_eq!(items.len(), 1);
     assert!(matches!(items[0], rustls_pemfile::Item::ECKey(_)));
 }
@@ -78,7 +102,9 @@ fn test_sec1_vs_pkcs8() {
         let data = include_bytes!("data/nistp256key.pem");
         let mut reader = BufReader::new(&data[..]);
 
-        let items = rustls_pemfile::read_all(&mut reader).unwrap();
+        let items = rustls_pemfile::read_all(&mut reader)
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
         assert!(matches!(items[0], rustls_pemfile::Item::ECKey(_)));
         println!("sec1 {:?}", items);
     }
@@ -86,7 +112,9 @@ fn test_sec1_vs_pkcs8() {
         let data = include_bytes!("data/nistp256key.pkcs8.pem");
         let mut reader = BufReader::new(&data[..]);
 
-        let items = rustls_pemfile::read_all(&mut reader).unwrap();
+        let items = rustls_pemfile::read_all(&mut reader)
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
         assert!(matches!(items[0], rustls_pemfile::Item::PKCS8Key(_)));
         println!("p8 {:?}", items);
     }
@@ -97,7 +125,9 @@ fn parse_in_order() {
     let data = include_bytes!("data/zen.pem");
     let mut reader = BufReader::new(&data[..]);
 
-    let items = rustls_pemfile::read_all(&mut reader).unwrap();
+    let items = rustls_pemfile::read_all(&mut reader)
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
     assert_eq!(items.len(), 9);
     assert!(matches!(items[0], rustls_pemfile::Item::X509Certificate(_)));
     assert!(matches!(items[1], rustls_pemfile::Item::X509Certificate(_)));


### PR DESCRIPTION
For more context, see https://github.com/rustls/pki-types/pull/1.

This adjusts the `Item` variant names to match the names used in pki-types (and make the names comply with the API naming guidelines).

I also tacked on a change to yield `impl Iterator` types from the various helper functions instead of allocating a `Vec` directly. This is maybe more efficient but may not pull off its weight in extra API complexity vs how this API gets used?

One option here would be to bring this functionality into rustls-pki-types directly under an extra feature flag (or perhaps unconditionally with a small internal base64 implementation, compared to the current dependency with aggressively-ish MSRV that is under not-so-great management).