### PR TITLE
Do not merge: use pki-types git branch for compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["network-programming", "cryptography"]
 
 [dependencies]
 base64 = { version = "0.21", default-features = false, features = ["alloc"] }
-pki-types = { package = "rustls-pki-types", version = "0.2" }
+pki-types = { package = "rustls-pki-types", version = "0.2.2", git = "https://github.com/rustls/pki-types", rev = "f5691e203714613cf0ff3316bad17523cd41b105" }
 
 [dev-dependencies]
 bencher = "0.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-pemfile"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 edition = "2018"
 license = "Apache-2.0 OR ISC OR MIT"
 readme = "README.md"


### PR DESCRIPTION
To allow rustls to use the different pki-types version in tests relying on pemfile, we need a pemfile version that relies on the same pki-types version.