### PR TITLE
Bump version to alpha.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-pemfile"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 edition = "2018"
 license = "Apache-2.0 OR ISC OR MIT"
 readme = "README.md"


### PR DESCRIPTION
This is useful for getting the new `private_key()` helper function out in a release.