### PR TITLE
Prepare 2.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-pemfile"
-version = "2.0.0-alpha.2"
+version = "2.0.0"
 edition = "2018"
 license = "Apache-2.0 OR ISC OR MIT"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["network-programming", "cryptography"]
 
 [dependencies]
 base64 = { version = "0.21", default-features = false, features = ["alloc"] }
-pki-types = { package = "rustls-pki-types", version = "0.2" }
+pki-types = { package = "rustls-pki-types", version = "1" }
 
 [dev-dependencies]
 bencher = "0.1.5"


### PR DESCRIPTION
Proposed release notes:

* **Improving API stability.** This crate now uses types from [rustls-pki-types](https://crates.io/crates/rustls-pki-types); we expect this to reduce the number of breaking changes in rustls ecosystem.
* **`no_std` support.** This crate can now work optionally without `std`.