### PR TITLE
ci: add scheduled build, use ubuntu-latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: rustls-pemfile
 
 jobs:
   rustfmt:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: cargo fmt --all -- --check
   clippy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: cargo clippy --locked --all-features --all-targets
   rustdoc:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: dtolnay/rust-toolchain@stable
       - uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
           - stable
           - beta
           - nightly
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         # but only stable on macos/windows (slower platforms)
         include:
           - os: macos-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,11 @@
-on: [push, pull_request, merge_group]
 name: rustls-pemfile
+
+on:
+  push:
+  pull_request:
+  merge_group:
+  schedule:
+    - cron: '0 18 * * *'
 
 jobs:
   rustfmt:


### PR DESCRIPTION
This repo was missing a scheduled build. I find these helpful for catching+squashing new nightly clippy findings before they bug someone opening a PR for something unrelated. 

Also switches the Linux runners to ubuntu-latest to match our pref elsewhere.