### PR TITLE
pemfile: fix clippy::useless_conversion finding

### DIFF
--- a/src/pemfile.rs
+++ b/src/pemfile.rs
@@ -75,7 +75,7 @@ impl Item {
                     Some(item) => return Ok(Some((item, iter.remainder()))),
                     None => continue,
                 },
-                Err(err) => return Err(err.into()),
+                Err(err) => return Err(err),
             }
         }
 


### PR DESCRIPTION
Of the form:
```
error: useless conversion to the same type: `rustls_pki_types::pem::Error`
  --> src/pemfile.rs:78:40
   |
78 |                 Err(err) => return Err(err.into()),
   |                                        ^^^^^^^^^^ help: consider removing `.into()`: `err`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
   = note: `-D clippy::useless-conversion` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::useless_conversion)]`

error: could not compile `rustls-pemfile` (lib) due to 1 previous error
```